### PR TITLE
Prisma Versioning Settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "prisma.pinToPrisma6": true
+}


### PR DESCRIPTION
Add `.vscode/settings.json` to pin PrismaORM to version 6.