### PR TITLE
Change email provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,10 +33,15 @@ JWT_REFRESH_EXP=604800 # 604800 (7 dias), 300 (5 min para testes)
 JWT_ISS="http://localhost:3001"
 JWT_AUD=bussola-financeira-dev
 
-# Email credentials for development
+# Email credentials for development (SMTP / mailtrap)
 EMAIL_HOST=
 EMAIL_PORT=
 EMAIL_USERNAME=
 EMAIL_PASSWORD=
 EMAIL_FROM_NAME="Bússola Financeira - dev"
 EMAIL_FROM_ADDRESS=
+
+# Emails credentials for staging/production (HTTP / resend)
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxx
+EMAIL_FROM_ADDRESS=onboarding@resend.dev
+EMAIL_FROM_NAME=Bússola Financeira

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "passport-jwt": "^4.0.1",
         "prisma": "^6.16.0",
         "reflect-metadata": "^0.2.2",
+        "resend": "^6.17.2",
         "rxjs": "^7.8.1",
         "sanitize-html": "^2.17.4",
         "swagger-themes": "^1.4.3"
@@ -4115,6 +4116,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -9049,6 +9056,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -13926,6 +13939,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -15120,6 +15139,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resend": {
+      "version": "6.17.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.17.2.tgz",
+      "integrity": "sha512-hbaXEORFIFfT2Bh03NsA/akTTTKkD1hiuJ88ke64c5dWVV6DyoLxzFve3OiZqVOQ+JKLJ5uVkPR6hlUslpJFoA==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -15780,6 +15820,16 @@
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "passport-jwt": "^4.0.1",
     "prisma": "^6.16.0",
     "reflect-metadata": "^0.2.2",
+    "resend": "^6.17.2",
     "rxjs": "^7.8.1",
     "sanitize-html": "^2.17.4",
     "swagger-themes": "^1.4.3"

--- a/src/infra/email/email-debug.controller.ts
+++ b/src/infra/email/email-debug.controller.ts
@@ -1,0 +1,38 @@
+import { InjectQueue } from "@nestjs/bull";
+import { Controller, Get } from "@nestjs/common";
+import { EMAIL_QUEUE } from "./constants/email.constant";
+import { Job, Queue } from "bull";
+
+@Controller("debug")
+export class EmailDebugController {
+  constructor(
+    @InjectQueue(EMAIL_QUEUE)
+    private readonly emailQueue: Queue,
+  ) {}
+
+  @Get("queue")
+  async queue() {
+    const waiting = await this.emailQueue.getWaiting();
+    const active = await this.emailQueue.getActive();
+    const failed = await this.emailQueue.getFailed();
+    const completed = await this.emailQueue.getCompleted();
+
+    const simplify = (jobs: Job[]) =>
+      jobs.map((job) => ({
+        id: job.id,
+        name: job.name,
+        attemptsMade: job.attemptsMade,
+        timestamp: job.timestamp,
+        processedOn: job.processedOn,
+        finishedOn: job.finishedOn,
+      }));
+
+    return {
+      counts: await this.emailQueue.getJobCounts(),
+      waiting: simplify(waiting),
+      active: simplify(active),
+      failed: simplify(failed),
+      completed: simplify(completed),
+    };
+  }
+}

--- a/src/infra/email/email.module.ts
+++ b/src/infra/email/email.module.ts
@@ -6,6 +6,9 @@ import { BullModule } from "@nestjs/bull";
 import { EMAIL_QUEUE } from "./constants/email.constant";
 import { EmailProcessor } from "./processors/email.processor";
 import { EmailDebugController } from "./email-debug.controller";
+import { MailtrapProvider } from "./providers/mailtrap.provider";
+import { ResendProvider } from "./providers/resend.provider";
+import { EmailProviderProtocol } from "./providers/email.provider.protocol";
 
 @Module({
   imports: [
@@ -17,6 +20,15 @@ import { EmailDebugController } from "./email-debug.controller";
       inject: [ConfigService],
       // eslint-disable-next-line @typescript-eslint/require-await
       useFactory: async (configService: ConfigService) => {
+        const isDevelopment =
+          configService.get<string>("NODE_ENV") === "development";
+
+        if (!isDevelopment) {
+          return {
+            transport: { jsonTransport: true },
+          };
+        }
+
         return {
           transport: {
             host: configService.get<string>("EMAIL_HOST"),
@@ -39,7 +51,26 @@ import { EmailDebugController } from "./email-debug.controller";
     }),
   ],
   controllers: [EmailDebugController],
-  providers: [EmailService, EmailProcessor],
+  providers: [
+    EmailService,
+    EmailProcessor,
+    MailtrapProvider,
+    ResendProvider,
+    {
+      provide: EmailProviderProtocol,
+      useFactory: (
+        configService: ConfigService,
+        mailtrapProvider: MailtrapProvider,
+        resendProvider: ResendProvider,
+      ): EmailProviderProtocol => {
+        const isDevelopment =
+          configService.get<string>("NODE_ENV") === "development";
+
+        return isDevelopment ? mailtrapProvider : resendProvider;
+      },
+      inject: [ConfigService, MailtrapProvider, ResendProvider],
+    },
+  ],
   exports: [EmailService],
 })
 export class EmailModule {}

--- a/src/infra/email/email.module.ts
+++ b/src/infra/email/email.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule, ConfigService } from "@nestjs/config";
 import { BullModule } from "@nestjs/bull";
 import { EMAIL_QUEUE } from "./constants/email.constant";
 import { EmailProcessor } from "./processors/email.processor";
+import { EmailDebugController } from "./email-debug.controller";
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { EmailProcessor } from "./processors/email.processor";
       },
     }),
   ],
+  controllers: [EmailDebugController],
   providers: [EmailService, EmailProcessor],
   exports: [EmailService],
 })

--- a/src/infra/email/processors/email.processor.ts
+++ b/src/infra/email/processors/email.processor.ts
@@ -7,7 +7,6 @@ import {
   Processor,
 } from "@nestjs/bull";
 import { EMAIL_QUEUE } from "../constants/email.constant";
-import { MailerService } from "@nestjs-modules/mailer";
 import { EmailJobs } from "../enums/email-queue.enum";
 import { Job } from "bull";
 import { ResetPasswordParams } from "../services/email.service";
@@ -16,12 +15,13 @@ import { resetPasswordTextTemplate } from "../templates/text/reset-password-txt.
 import { resetPasswordNotificationHtmlTemplate } from "../templates/html/reset-password-notification-html.template";
 import { resetPasswordNotificationTextTemplate } from "../templates/text/reset-password-notification-txt.template";
 import { Logger } from "@nestjs/common";
+import { EmailProviderProtocol } from "../providers/email.provider.protocol";
 
 @Processor(EMAIL_QUEUE)
 export class EmailProcessor {
   private readonly logger = new Logger(EmailProcessor.name);
 
-  constructor(private readonly mailerService: MailerService) {}
+  constructor(private readonly emailProvider: EmailProviderProtocol) {}
 
   onModuleInit() {
     this.logger.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
@@ -54,7 +54,7 @@ export class EmailProcessor {
     try {
       this.logger.log(`Processando envio de e-mail para o job ${job.id}`);
 
-      await this.mailerService.sendMail({
+      await this.emailProvider.sendMail({
         to: email,
         subject,
         html: resetPasswordHtmlTemplate(userName, resetUrl, subject),
@@ -86,7 +86,7 @@ export class EmailProcessor {
     try {
       this.logger.log(`Processando envio de e-mail para o job ${job.id}`);
 
-      await this.mailerService.sendMail({
+      await this.emailProvider.sendMail({
         to: email,
         subject,
         html: resetPasswordNotificationHtmlTemplate(userName, subject),

--- a/src/infra/email/providers/email.provider.protocol.ts
+++ b/src/infra/email/providers/email.provider.protocol.ts
@@ -1,0 +1,10 @@
+export interface SendMailOptions {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export abstract class EmailProviderProtocol {
+  abstract sendMail(options: SendMailOptions): Promise<void>;
+}

--- a/src/infra/email/providers/mailtrap.provider.ts
+++ b/src/infra/email/providers/mailtrap.provider.ts
@@ -1,0 +1,18 @@
+import { MailerService } from "@nestjs-modules/mailer";
+import { Injectable, Logger } from "@nestjs/common";
+import {
+  EmailProviderProtocol,
+  SendMailOptions,
+} from "./email.provider.protocol";
+
+@Injectable()
+export class MailtrapProvider implements EmailProviderProtocol {
+  private readonly logger = new Logger(MailtrapProvider.name);
+
+  constructor(private readonly mailerService: MailerService) {}
+
+  async sendMail(options: SendMailOptions): Promise<void> {
+    await this.mailerService.sendMail(options);
+    this.logger.log(`[Mailtrap] Email sent to: ${options.to}`);
+  }
+}

--- a/src/infra/email/providers/resend.provider.ts
+++ b/src/infra/email/providers/resend.provider.ts
@@ -8,22 +8,19 @@ import {
 
 @Injectable()
 export class ResendProvider implements EmailProviderProtocol {
-  private readonly resend: Resend;
-  private readonly from: string;
+  private resend: Resend | null = null;
   private readonly logger = new Logger(ResendProvider.name);
 
-  constructor(private readonly configService: ConfigService) {
-    const RESEND_API_KEY = this.configService.get<string>("RESEND_API_KEY");
-    this.resend = new Resend(RESEND_API_KEY);
+  constructor(private readonly configService: ConfigService) {}
+
+  async sendMail(options: SendMailOptions): Promise<void> {
+    const resend = this.getClient();
 
     const fromName = this.configService.get<string>("EMAIL_FROM_NAME");
     const fromAddress = this.configService.get<string>("EMAIL_FROM_ADDRESS");
-    this.from = `${fromName} <${fromAddress}>`;
-  }
 
-  async sendMail(options: SendMailOptions): Promise<void> {
-    const { data, error } = await this.resend.emails.send({
-      from: this.from,
+    const { data, error } = await resend.emails.send({
+      from: `${fromName} <${fromAddress}>`,
       to: options.to,
       subject: options.subject,
       html: options.html,
@@ -37,4 +34,20 @@ export class ResendProvider implements EmailProviderProtocol {
 
     this.logger.log(`[Resend] Email sent to: ${options.to}. ID: ${data?.id}`);
   }
+
+  getClient(): Resend {
+    if (!this.resend) {
+      const RESEND_API_KEY = this.configService.get<string>("RESEND_API_KEY");
+      this.resend = new Resend(RESEND_API_KEY);
+    }
+
+    return this.resend;
+  }
 }
+
+// const RESEND_API_KEY = this.configService.get<string>("RESEND_API_KEY");
+// this.resend = new Resend(RESEND_API_KEY);
+
+// const fromName = this.configService.get<string>("EMAIL_FROM_NAME");
+// const fromAddress = this.configService.get<string>("EMAIL_FROM_ADDRESS");
+// this.from = `${fromName} <${fromAddress}>`;

--- a/src/infra/email/providers/resend.provider.ts
+++ b/src/infra/email/providers/resend.provider.ts
@@ -1,0 +1,40 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Resend } from "resend";
+import {
+  EmailProviderProtocol,
+  SendMailOptions,
+} from "./email.provider.protocol";
+
+@Injectable()
+export class ResendProvider implements EmailProviderProtocol {
+  private readonly resend: Resend;
+  private readonly from: string;
+  private readonly logger = new Logger(ResendProvider.name);
+
+  constructor(private readonly configService: ConfigService) {
+    const RESEND_API_KEY = this.configService.get<string>("RESEND_API_KEY");
+    this.resend = new Resend(RESEND_API_KEY);
+
+    const fromName = this.configService.get<string>("EMAIL_FROM_NAME");
+    const fromAddress = this.configService.get<string>("EMAIL_FROM_ADDRESS");
+    this.from = `${fromName} <${fromAddress}>`;
+  }
+
+  async sendMail(options: SendMailOptions): Promise<void> {
+    const { data, error } = await this.resend.emails.send({
+      from: this.from,
+      to: options.to,
+      subject: options.subject,
+      html: options.html,
+      text: options.text,
+    });
+
+    if (error) {
+      this.logger.error(`[Resend] Re-throwing the error for queue retry`);
+      throw new Error(`[Resend] Error sending email: ${error.message}`);
+    }
+
+    this.logger.log(`[Resend] Email sent to: ${options.to}. ID: ${data?.id}`);
+  }
+}

--- a/src/infra/email/services/email.service.ts
+++ b/src/infra/email/services/email.service.ts
@@ -30,7 +30,10 @@ export class EmailService {
         { priority: 1, attempts: 5 },
       );
 
+      this.logger.log(await job.getState());
+      this.logger.log(`Job criado: ${job.id}`);
       this.logger.log(`Job #${job.id} adicionado à fila para: ${email}`);
+      this.logger.log(await this.emailQueue.getJobCounts());
 
       return { jobId: job.id };
     } catch (error: any) {
@@ -51,7 +54,10 @@ export class EmailService {
         { priority: 1, attempts: 5 },
       );
 
+      this.logger.log(await job.getState());
+      this.logger.log(`Job criado: ${job.id}`);
       this.logger.log(`Job #${job.id} adicionado à fila para: ${email}`);
+      this.logger.log(await this.emailQueue.getJobCounts());
 
       return { jobId: job.id };
     } catch (error: any) {

--- a/src/infra/queue/queue.module.ts
+++ b/src/infra/queue/queue.module.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { Module } from "@nestjs/common";
 import { BullModule } from "@nestjs/bull";
 import { ConfigModule, ConfigService } from "@nestjs/config";
@@ -9,7 +10,8 @@ import { ConfigModule, ConfigService } from "@nestjs/config";
       inject: [ConfigService],
       // eslint-disable-next-line @typescript-eslint/require-await
       useFactory: async (configService: ConfigService) => {
-        const redisUrl = configService.get<string>("REDIS_URL");
+        const isDevelopment = configService.get("NODE_ENV") === "development";
+        // const redisUrl = configService.get<string>("REDIS_URL");
 
         const defaultJobOptions = {
           removeOnComplete: {
@@ -26,28 +28,55 @@ import { ConfigModule, ConfigService } from "@nestjs/config";
           },
         };
 
-        if (redisUrl) {
+        // if (redisUrl) {
+        //   return {
+        //     url: redisUrl,
+        //     redis: {
+        //       tls: {
+        //         rejectUnauthorized: false,
+        //       },
+        //       maxRetriesPerRequest: null,
+        //       enableReadyCheck: false,
+        //       connectTimeout: 30000,
+        //     },
+        //     defaultJobOptions,
+        //   };
+        // }
+
+        if (isDevelopment) {
           return {
-            url: redisUrl,
             redis: {
-              tls: {
-                rejectUnauthorized: false,
-              },
-              maxRetriesPerRequest: null,
-              enableReadyCheck: false,
-              connectTimeout: 30000,
+              host: configService.get<string>("REDIS_HOST", "localhost"),
+              port: configService.get<number>("REDIS_PORT", 6379),
             },
             defaultJobOptions,
           };
         }
 
+        console.log({
+          host: configService.get("REDIS_HOST"),
+          port: configService.get("REDIS_PORT"),
+          username: configService.get("REDIS_USERNAME"),
+        });
+
         return {
           redis: {
-            host: configService.get<string>("REDIS_HOST", "localhost"),
-            port: configService.get<number>("REDIS_PORT", 6379),
+            host: configService.get<string>("REDIS_HOST"),
+            port: configService.get<number>("REDIS_PORT"),
+            username: configService.get<string>("REDIS_USERNAME"),
+            password: configService.get<string>("REDIS_PASSWORD"),
+            tls: {},
           },
           defaultJobOptions,
         };
+
+        // return {
+        //   redis: {
+        //     host: configService.get<string>("REDIS_HOST", "localhost"),
+        //     port: configService.get<number>("REDIS_PORT", 6379),
+        //   },
+        //   defaultJobOptions,
+        // };
       },
     }),
   ],

--- a/test/helpers/create-test-app.helper.ts
+++ b/test/helpers/create-test-app.helper.ts
@@ -15,6 +15,8 @@ import { AllExceptionsFilter } from "src/common/filters/all-exceptions-filter.fi
 import { TestAuthHelper } from "./test-auth.helper";
 import { TestJwtHelper } from "./test-jwt.helper";
 import { JwtService } from "@nestjs/jwt";
+import { QueueModule } from "src/infra/queue/queue.module";
+import { EmailModule } from "src/infra/email/email.module";
 
 export interface TestContext {
   app: INestApplication;
@@ -32,6 +34,8 @@ export async function createTestApp(): Promise<TestContext> {
         ignoreEnvFile: true,
       }),
       PrismaModule,
+      QueueModule,
+      EmailModule,
       UserModule,
       AuthModule,
       AdminModule,


### PR DESCRIPTION
The app now uses `mailtrap` (SMTP) for development and `resend` (HTTP) for staging and production.

This decision was made because the Render service does not allow free accounts to send emails using the SMTP protocol